### PR TITLE
updated the centos7 branch without nvidia centos7 branch

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,7 +1,7 @@
 image: docker:stable
 
-services:
-    - docker:stable-dind
+# NOTE: The docker:stable-dind service is not used here because --add-runtime=nvidia does not work and we need the runtime to
+#       perform tests
 
 variables:
   GIT_DEPTH: "1"
@@ -24,8 +24,13 @@ stages:
   - test
   - deploy
 
+.tags_template: &tags_definition
+  tags:
+    - cuda-docker-10.1
+
 .cuda_template: &cuda_definition
   stage: cuda
+  <<: *tags_definition
   script:
     - VERSION="${CI_JOB_NAME:1}"
     - docker build -t "${IMAGE_NAME}:${VERSION}-runtime-${OS}"
@@ -42,14 +47,10 @@ stages:
     - if [[ "${LATEST}" == true ]]; then
         docker tag "${IMAGE_NAME}:${VERSION}-devel-${OS}" "${IMAGE_NAME}:latest";
       fi
-    # A push must be done immediately after the build because a separate deploy job might not get the same runner. This sucks.
-    # FIXME: remove once https://gitlab.com/gitlab-org/gitlab-ce/issues/29447 is implemented
-    - if [[ -z $NV_CI_INTERNAL ]]; then
-        docker images | grep ${IMAGE_NAME} | grep "${VERSION}" | grep "\(${OS}\ \|-base\ \|-devel\ \|-runtime\ \)" | awk '{ print $1":"$2 }' | xargs -L1 docker push;
-      fi
 
 .cuda_base_template: &cuda_base_definition
   stage: cuda
+  <<: *tags_definition
   script:
     - VERSION="${CI_JOB_NAME:1}"
     - docker build -t "${IMAGE_NAME}:${VERSION}-base-${OS}"
@@ -71,14 +72,10 @@ stages:
     - if [[ "${LATEST}" == true ]]; then
         docker tag "${IMAGE_NAME}:${VERSION}-devel-${OS}" "${IMAGE_NAME}:latest";
       fi
-    # A push must be done immediately after the build because a separate deploy job might not get the same runner. This sucks.
-    # FIXME: remove once https://gitlab.com/gitlab-org/gitlab-ce/issues/29447 is implemented
-    - if [[ -z $NV_CI_INTERNAL ]]; then
-        docker images | grep ${IMAGE_NAME} | grep "${VERSION}" | grep "\(${OS}\ \|-base\ \|-devel\ \|-runtime\ \)" | awk '{ print $1":"$2 }' | xargs -L1 docker push;
-      fi
 
 .cudnn_template: &cudnn_definition
   stage: cudnn
+  <<: *tags_definition
   script:
     - VERSION="${CI_JOB_NAME:1}"
     - CUDA_VERSION="${VERSION%-*}"
@@ -95,18 +92,10 @@ stages:
         docker tag "${IMAGE_NAME}:${VERSION}-runtime-${OS}" "${IMAGE_NAME}:${VERSION}-runtime";
         docker tag "${IMAGE_NAME}:${VERSION}-devel-${OS}" "${IMAGE_NAME}:${VERSION}-devel";
       fi
-    # A push must be done immediately after the build because a separate deploy job might not get the same runner. This sucks.
-    # FIXME: remove once https://gitlab.com/gitlab-org/gitlab-ce/issues/29447 is implemented
-    - if [[ -z $NV_CI_INTERNAL ]]; then
-        docker images | grep ${IMAGE_NAME} | grep "${CUDA_VERSION}" | grep "\(${OS}\ \|-base\ \|-devel\ \|-runtime\ \)" | awk '{ print $1":"$2 }' | xargs -L1 docker push;
-      fi
 
 .test_template: &test_definition
   stage: test
-  only:
-    variables:
-      # Not implemented yet for gitlab.com
-      - $NV_CI_INTERNAL
+  <<: *tags_definition
   script:
     - export CUDA_VERSION="${CI_JOB_NAME%-*}"
     - export CUDA_TEST_VERSION="${CUDA_VERSION:1}"
@@ -118,13 +107,12 @@ stages:
 
 .deploy_template: &deploy_definition
   stage: deploy
-  only:
-    variables:
-      # Not implemented yet for gitlab.com
-      - $NV_CI_INTERNAL
+  <<: *tags_definition
   script:
-    - CUDA_VERSION="${CI_JOB_NAME%-*}"
-    - docker images | grep ${IMAGE_NAME} | grep "${CUDA_VERSION:1}" | grep "\(${OS}\ \|-base\ \|-devel\ \|-runtime\ \)" | awk '{ print $1":"$2 }' | xargs -L 1 docker push
+    - docker images | grep ${IMAGE_NAME} | grep "${IMAGE_NAME}\ *${CI_JOB_NAME:1:-7}" | grep "\(${OS}\ \|-base\ \|-devel\ \|-runtime\ \)" | awk '{ print $1":"$2 }' | xargs -L1 docker push;
+    - if [[ ! -z $LATEST ]]; then
+        docker push ${IMAGE_NAME}:latest;
+      fi
 
 v8.0:
   <<: *cuda_definition
@@ -195,22 +183,14 @@ v10.0-deploy:
   <<: *deploy_definition
 
 v10.1:
-  # tags:
-    # - cuda-docker
   <<: *cuda_base_definition
 
 v10.1-cudnn7:
-  # tags:
-    # - cuda-docker
   <<: *cudnn_definition
 
 v10.1-test:
-  # tags:
-    # - cuda-docker-10.1
   <<: *test_definition
 
 v10.1-deploy:
-  # tags:
-    # - cuda-docker-10.1
   <<: *deploy_definition
 

--- a/10.0/base/Dockerfile
+++ b/10.0/base/Dockerfile
@@ -27,4 +27,4 @@ ENV LD_LIBRARY_PATH /usr/local/nvidia/lib:/usr/local/nvidia/lib64
 # nvidia-container-runtime
 ENV NVIDIA_VISIBLE_DEVICES all
 ENV NVIDIA_DRIVER_CAPABILITIES compute,utility
-ENV NVIDIA_REQUIRE_CUDA "cuda>=10.0 brand=tesla,driver>=384,driver<385"
+ENV NVIDIA_REQUIRE_CUDA "cuda>=10.0 brand=tesla,driver>=384,driver<385 brand=tesla,driver>=410,driver<411"

--- a/10.0/base/Dockerfile
+++ b/10.0/base/Dockerfile
@@ -13,7 +13,7 @@ ENV CUDA_PKG_VERSION 10-0-$CUDA_VERSION-1
 # For libraries in the cuda-compat-* package: https://docs.nvidia.com/cuda/eula/index.html#attachment-a
 RUN yum install -y \
         cuda-cudart-$CUDA_PKG_VERSION \
-        cuda-compat-10-0-410.48 && \
+        cuda-compat-10-0 && \
     ln -s cuda-10.0 /usr/local/cuda && \
     rm -rf /var/cache/yum/*
 

--- a/10.0/devel/Dockerfile
+++ b/10.0/devel/Dockerfile
@@ -1,4 +1,4 @@
-ARG IMAGE_NAME
+
 FROM ${IMAGE_NAME}:10.0-runtime-centos7
 LABEL maintainer "NVIDIA CORPORATION <cudatools@nvidia.com>"
 

--- a/10.0/devel/cudnn7/Dockerfile
+++ b/10.0/devel/cudnn7/Dockerfile
@@ -2,13 +2,13 @@ ARG IMAGE_NAME
 FROM ${IMAGE_NAME}:10.0-devel-centos7
 LABEL maintainer "NVIDIA CORPORATION <cudatools@nvidia.com>"
 
-ENV CUDNN_VERSION 7.5.0.56
+ENV CUDNN_VERSION 7.5.1.10
 LABEL com.nvidia.cudnn.version="${CUDNN_VERSION}"
 
 # cuDNN license: https://developer.nvidia.com/cudnn/license_agreement
-RUN CUDNN_DOWNLOAD_SUM=701097882cb745d4683bb7ff6c33b8a35c7c81be31bac78f05bad130e7e0b781 && \
-    curl -fsSL http://developer.download.nvidia.com/compute/redist/cudnn/v7.5.0/cudnn-10.0-linux-x64-v7.5.0.56.tgz -O && \
-    echo "$CUDNN_DOWNLOAD_SUM  cudnn-10.0-linux-x64-v7.5.0.56.tgz" | sha256sum -c - && \
-    tar --no-same-owner -xzf cudnn-10.0-linux-x64-v7.5.0.56.tgz -C /usr/local && \
-    rm cudnn-10.0-linux-x64-v7.5.0.56.tgz && \
+RUN CUDNN_DOWNLOAD_SUM=c0a4ec438920aa581dd567117b9c316745b4a451ac739b1e04939a3d8b229985 && \
+    curl -fsSL http://developer.download.nvidia.com/compute/redist/cudnn/v7.5.1/cudnn-10.0-linux-x64-v7.5.1.10.tgz -O && \
+    echo "$CUDNN_DOWNLOAD_SUM  cudnn-10.0-linux-x64-v7.5.1.10.tgz" | sha256sum -c - && \
+    tar --no-same-owner -xzf cudnn-10.0-linux-x64-v7.5.1.10.tgz -C /usr/local && \
+    rm cudnn-10.0-linux-x64-v7.5.1.10.tgz && \
     ldconfig

--- a/10.0/devel/cudnn7/Dockerfile
+++ b/10.0/devel/cudnn7/Dockerfile
@@ -2,13 +2,13 @@ ARG IMAGE_NAME
 FROM ${IMAGE_NAME}:10.0-devel-centos7
 LABEL maintainer "NVIDIA CORPORATION <cudatools@nvidia.com>"
 
-ENV CUDNN_VERSION 7.5.1.10
+ENV CUDNN_VERSION 7.6.0.64
 LABEL com.nvidia.cudnn.version="${CUDNN_VERSION}"
 
 # cuDNN license: https://developer.nvidia.com/cudnn/license_agreement
-RUN CUDNN_DOWNLOAD_SUM=c0a4ec438920aa581dd567117b9c316745b4a451ac739b1e04939a3d8b229985 && \
-    curl -fsSL http://developer.download.nvidia.com/compute/redist/cudnn/v7.5.1/cudnn-10.0-linux-x64-v7.5.1.10.tgz -O && \
-    echo "$CUDNN_DOWNLOAD_SUM  cudnn-10.0-linux-x64-v7.5.1.10.tgz" | sha256sum -c - && \
-    tar --no-same-owner -xzf cudnn-10.0-linux-x64-v7.5.1.10.tgz -C /usr/local && \
-    rm cudnn-10.0-linux-x64-v7.5.1.10.tgz && \
+RUN CUDNN_DOWNLOAD_SUM=c4e1ee4168f4cadabaa989487a47bed09f34d34e35398b6084a2699d11bd2560 && \
+    curl -fsSL http://developer.download.nvidia.com/compute/redist/cudnn/v7.6.0/cudnn-10.0-linux-x64-v7.6.0.64.tgz -O && \
+    echo "$CUDNN_DOWNLOAD_SUM  cudnn-10.0-linux-x64-v7.6.0.64.tgz" | sha256sum -c - && \
+    tar --no-same-owner -xzf cudnn-10.0-linux-x64-v7.6.0.64.tgz -C /usr/local && \
+    rm cudnn-10.0-linux-x64-v7.6.0.64.tgz && \
     ldconfig

--- a/10.0/devel/cudnn7/Dockerfile
+++ b/10.0/devel/cudnn7/Dockerfile
@@ -1,4 +1,4 @@
-ARG IMAGE_NAME
+
 FROM ${IMAGE_NAME}:10.0-devel-centos7
 LABEL maintainer "NVIDIA CORPORATION <cudatools@nvidia.com>"
 

--- a/10.0/runtime/Dockerfile
+++ b/10.0/runtime/Dockerfile
@@ -1,4 +1,4 @@
-ARG IMAGE_NAME
+
 FROM ${IMAGE_NAME}:10.0-base-centos7
 LABEL maintainer "NVIDIA CORPORATION <cudatools@nvidia.com>"
 

--- a/10.0/runtime/cudnn7/Dockerfile
+++ b/10.0/runtime/cudnn7/Dockerfile
@@ -2,13 +2,13 @@ ARG IMAGE_NAME
 FROM ${IMAGE_NAME}:10.0-runtime-centos7
 LABEL maintainer "NVIDIA CORPORATION <cudatools@nvidia.com>"
 
-ENV CUDNN_VERSION 7.5.0.56
+ENV CUDNN_VERSION 7.5.1.10
 LABEL com.nvidia.cudnn.version="${CUDNN_VERSION}"
 
 # cuDNN license: https://developer.nvidia.com/cudnn/license_agreement
-RUN CUDNN_DOWNLOAD_SUM=701097882cb745d4683bb7ff6c33b8a35c7c81be31bac78f05bad130e7e0b781 && \
-    curl -fsSL http://developer.download.nvidia.com/compute/redist/cudnn/v7.5.0/cudnn-10.0-linux-x64-v7.5.0.56.tgz -O && \
-    echo "$CUDNN_DOWNLOAD_SUM  cudnn-10.0-linux-x64-v7.5.0.56.tgz" | sha256sum -c - && \
-    tar --no-same-owner -xzf cudnn-10.0-linux-x64-v7.5.0.56.tgz -C /usr/local --wildcards 'cuda/lib64/libcudnn.so.*' && \
-    rm cudnn-10.0-linux-x64-v7.5.0.56.tgz && \
+RUN CUDNN_DOWNLOAD_SUM=c0a4ec438920aa581dd567117b9c316745b4a451ac739b1e04939a3d8b229985 && \
+    curl -fsSL http://developer.download.nvidia.com/compute/redist/cudnn/v7.5.1/cudnn-10.0-linux-x64-v7.5.1.10.tgz -O && \
+    echo "$CUDNN_DOWNLOAD_SUM  cudnn-10.0-linux-x64-v7.5.1.10.tgz" | sha256sum -c - && \
+    tar --no-same-owner -xzf cudnn-10.0-linux-x64-v7.5.1.10.tgz -C /usr/local --wildcards 'cuda/lib64/libcudnn.so.*' && \
+    rm cudnn-10.0-linux-x64-v7.5.1.10.tgz && \
     ldconfig

--- a/10.0/runtime/cudnn7/Dockerfile
+++ b/10.0/runtime/cudnn7/Dockerfile
@@ -2,13 +2,13 @@ ARG IMAGE_NAME
 FROM ${IMAGE_NAME}:10.0-runtime-centos7
 LABEL maintainer "NVIDIA CORPORATION <cudatools@nvidia.com>"
 
-ENV CUDNN_VERSION 7.5.1.10
+ENV CUDNN_VERSION 7.6.0.64
 LABEL com.nvidia.cudnn.version="${CUDNN_VERSION}"
 
 # cuDNN license: https://developer.nvidia.com/cudnn/license_agreement
-RUN CUDNN_DOWNLOAD_SUM=c0a4ec438920aa581dd567117b9c316745b4a451ac739b1e04939a3d8b229985 && \
-    curl -fsSL http://developer.download.nvidia.com/compute/redist/cudnn/v7.5.1/cudnn-10.0-linux-x64-v7.5.1.10.tgz -O && \
-    echo "$CUDNN_DOWNLOAD_SUM  cudnn-10.0-linux-x64-v7.5.1.10.tgz" | sha256sum -c - && \
-    tar --no-same-owner -xzf cudnn-10.0-linux-x64-v7.5.1.10.tgz -C /usr/local --wildcards 'cuda/lib64/libcudnn.so.*' && \
-    rm cudnn-10.0-linux-x64-v7.5.1.10.tgz && \
+RUN CUDNN_DOWNLOAD_SUM=c4e1ee4168f4cadabaa989487a47bed09f34d34e35398b6084a2699d11bd2560 && \
+    curl -fsSL http://developer.download.nvidia.com/compute/redist/cudnn/v7.6.0/cudnn-10.0-linux-x64-v7.6.0.64.tgz -O && \
+    echo "$CUDNN_DOWNLOAD_SUM  cudnn-10.0-linux-x64-v7.6.0.64.tgz" | sha256sum -c - && \
+    tar --no-same-owner -xzf cudnn-10.0-linux-x64-v7.6.0.64.tgz -C /usr/local --wildcards 'cuda/lib64/libcudnn.so.*' && \
+    rm cudnn-10.0-linux-x64-v7.6.0.64.tgz && \
     ldconfig

--- a/10.0/runtime/cudnn7/Dockerfile
+++ b/10.0/runtime/cudnn7/Dockerfile
@@ -1,4 +1,4 @@
-ARG IMAGE_NAME
+
 FROM ${IMAGE_NAME}:10.0-runtime-centos7
 LABEL maintainer "NVIDIA CORPORATION <cudatools@nvidia.com>"
 

--- a/10.1/base/Dockerfile
+++ b/10.1/base/Dockerfile
@@ -27,4 +27,4 @@ ENV LD_LIBRARY_PATH /usr/local/nvidia/lib:/usr/local/nvidia/lib64
 # nvidia-container-runtime
 ENV NVIDIA_VISIBLE_DEVICES all
 ENV NVIDIA_DRIVER_CAPABILITIES compute,utility
-ENV NVIDIA_REQUIRE_CUDA "cuda>=10.1 brand=tesla,driver>=418,driver<419"
+ENV NVIDIA_REQUIRE_CUDA "cuda>=10.1 brand=tesla,driver>=384,driver<385 brand=tesla,driver>=410,driver<411"

--- a/10.1/base/Dockerfile
+++ b/10.1/base/Dockerfile
@@ -13,7 +13,7 @@ ENV CUDA_PKG_VERSION 10-1-$CUDA_VERSION-1
 # For libraries in the cuda-compat-* package: https://docs.nvidia.com/cuda/eula/index.html#attachment-a
 RUN yum install -y \
         cuda-cudart-$CUDA_PKG_VERSION \
-        cuda-compat-10-1-418.39 && \
+        cuda-compat-10-1 && \
     ln -s cuda-10.1 /usr/local/cuda && \
     rm -rf /var/cache/yum/*
 

--- a/10.1/base/Dockerfile
+++ b/10.1/base/Dockerfile
@@ -7,7 +7,7 @@ RUN NVIDIA_GPGKEY_SUM=d1be581509378368edeec8c1eb2958702feedf3bc3d17011adbf24efac
 
 COPY cuda.repo /etc/yum.repos.d/cuda.repo
 
-ENV CUDA_VERSION 10.1.105
+ENV CUDA_VERSION 10.1.168
 
 ENV CUDA_PKG_VERSION 10-1-$CUDA_VERSION-1
 # For libraries in the cuda-compat-* package: https://docs.nvidia.com/cuda/eula/index.html#attachment-a
@@ -27,4 +27,4 @@ ENV LD_LIBRARY_PATH /usr/local/nvidia/lib:/usr/local/nvidia/lib64
 # nvidia-container-runtime
 ENV NVIDIA_VISIBLE_DEVICES all
 ENV NVIDIA_DRIVER_CAPABILITIES compute,utility
-ENV NVIDIA_REQUIRE_CUDA "cuda>=10.1 brand=tesla,driver>=384,driver<385 brand=tesla,driver>=410,driver<411"
+ENV NVIDIA_REQUIRE_CUDA "cuda>=10.1 brand=tesla,driver>=384,driver<385 brand=tesla,driver>=396,driver<397 brand=tesla,driver>=410,driver<411"

--- a/10.1/devel/Dockerfile
+++ b/10.1/devel/Dockerfile
@@ -1,4 +1,4 @@
-ARG IMAGE_NAME
+
 FROM ${IMAGE_NAME}:10.1-runtime-centos7
 LABEL maintainer "NVIDIA CORPORATION <cudatools@nvidia.com>"
 

--- a/10.1/devel/cudnn7/Dockerfile
+++ b/10.1/devel/cudnn7/Dockerfile
@@ -2,13 +2,13 @@ ARG IMAGE_NAME
 FROM ${IMAGE_NAME}:10.1-devel-centos7
 LABEL maintainer "NVIDIA CORPORATION <cudatools@nvidia.com>"
 
-ENV CUDNN_VERSION 7.5.0.56
+ENV CUDNN_VERSION 7.5.1.10
 LABEL com.nvidia.cudnn.version="${CUDNN_VERSION}"
 
 # cuDNN license: https://developer.nvidia.com/cudnn/license_agreement
-RUN CUDNN_DOWNLOAD_SUM=c31697d6b71afe62838ad2e57da3c3c9419c4e9f5635d14b683ebe63f904fbc8 && \
-    curl -fsSL http://developer.download.nvidia.com/compute/redist/cudnn/v7.5.0/cudnn-10.1-linux-x64-v7.5.0.56.tgz -O && \
-    echo "$CUDNN_DOWNLOAD_SUM  cudnn-10.1-linux-x64-v7.5.0.56.tgz" | sha256sum -c - && \
-    tar --no-same-owner -xzf cudnn-10.1-linux-x64-v7.5.0.56.tgz -C /usr/local && \
-    rm cudnn-10.1-linux-x64-v7.5.0.56.tgz && \
+RUN CUDNN_DOWNLOAD_SUM=2c833f43c9147d9a25a20947a4c5a5f5c33b2443240fd767f63b330c482e68e0 && \
+    curl -fsSL http://developer.download.nvidia.com/compute/redist/cudnn/v7.5.1/cudnn-10.1-linux-x64-v7.5.1.10.tgz -O && \
+    echo "$CUDNN_DOWNLOAD_SUM  cudnn-10.1-linux-x64-v7.5.1.10.tgz" | sha256sum -c - && \
+    tar --no-same-owner -xzf cudnn-10.1-linux-x64-v7.5.1.10.tgz -C /usr/local && \
+    rm cudnn-10.1-linux-x64-v7.5.1.10.tgz && \
     ldconfig

--- a/10.1/devel/cudnn7/Dockerfile
+++ b/10.1/devel/cudnn7/Dockerfile
@@ -2,13 +2,13 @@ ARG IMAGE_NAME
 FROM ${IMAGE_NAME}:10.1-devel-centos7
 LABEL maintainer "NVIDIA CORPORATION <cudatools@nvidia.com>"
 
-ENV CUDNN_VERSION 7.5.1.10
+ENV CUDNN_VERSION 7.6.0.64
 LABEL com.nvidia.cudnn.version="${CUDNN_VERSION}"
 
 # cuDNN license: https://developer.nvidia.com/cudnn/license_agreement
-RUN CUDNN_DOWNLOAD_SUM=2c833f43c9147d9a25a20947a4c5a5f5c33b2443240fd767f63b330c482e68e0 && \
-    curl -fsSL http://developer.download.nvidia.com/compute/redist/cudnn/v7.5.1/cudnn-10.1-linux-x64-v7.5.1.10.tgz -O && \
-    echo "$CUDNN_DOWNLOAD_SUM  cudnn-10.1-linux-x64-v7.5.1.10.tgz" | sha256sum -c - && \
-    tar --no-same-owner -xzf cudnn-10.1-linux-x64-v7.5.1.10.tgz -C /usr/local && \
-    rm cudnn-10.1-linux-x64-v7.5.1.10.tgz && \
+RUN CUDNN_DOWNLOAD_SUM=e956c6f9222fcb867a10449cfc76dee5cfd7c7531021d95fe9586d7e043b57d7 && \
+    curl -fsSL http://developer.download.nvidia.com/compute/redist/cudnn/v7.6.0/cudnn-10.1-linux-x64-v7.6.0.64.tgz -O && \
+    echo "$CUDNN_DOWNLOAD_SUM  cudnn-10.1-linux-x64-v7.6.0.64.tgz" | sha256sum -c - && \
+    tar --no-same-owner -xzf cudnn-10.1-linux-x64-v7.6.0.64.tgz -C /usr/local && \
+    rm cudnn-10.1-linux-x64-v7.6.0.64.tgz && \
     ldconfig

--- a/10.1/devel/cudnn7/Dockerfile
+++ b/10.1/devel/cudnn7/Dockerfile
@@ -1,4 +1,4 @@
-ARG IMAGE_NAME
+
 FROM ${IMAGE_NAME}:10.1-devel-centos7
 LABEL maintainer "NVIDIA CORPORATION <cudatools@nvidia.com>"
 

--- a/10.1/runtime/Dockerfile
+++ b/10.1/runtime/Dockerfile
@@ -1,4 +1,4 @@
-ARG IMAGE_NAME
+
 FROM ${IMAGE_NAME}:10.1-base-centos7
 LABEL maintainer "NVIDIA CORPORATION <cudatools@nvidia.com>"
 

--- a/10.1/runtime/cudnn7/Dockerfile
+++ b/10.1/runtime/cudnn7/Dockerfile
@@ -2,13 +2,13 @@ ARG IMAGE_NAME
 FROM ${IMAGE_NAME}:10.1-runtime-centos7
 LABEL maintainer "NVIDIA CORPORATION <cudatools@nvidia.com>"
 
-ENV CUDNN_VERSION 7.5.1.10
+ENV CUDNN_VERSION 7.6.0.64
 LABEL com.nvidia.cudnn.version="${CUDNN_VERSION}"
 
 # cuDNN license: https://developer.nvidia.com/cudnn/license_agreement
-RUN CUDNN_DOWNLOAD_SUM=2c833f43c9147d9a25a20947a4c5a5f5c33b2443240fd767f63b330c482e68e0 && \
-    curl -fsSL http://developer.download.nvidia.com/compute/redist/cudnn/v7.5.1/cudnn-10.1-linux-x64-v7.5.1.10.tgz -O && \
-    echo "$CUDNN_DOWNLOAD_SUM  cudnn-10.1-linux-x64-v7.5.1.10.tgz" | sha256sum -c - && \
-    tar --no-same-owner -xzf cudnn-10.1-linux-x64-v7.5.1.10.tgz -C /usr/local --wildcards 'cuda/lib64/libcudnn.so.*' && \
-    rm cudnn-10.1-linux-x64-v7.5.1.10.tgz && \
+RUN CUDNN_DOWNLOAD_SUM=e956c6f9222fcb867a10449cfc76dee5cfd7c7531021d95fe9586d7e043b57d7 && \
+    curl -fsSL http://developer.download.nvidia.com/compute/redist/cudnn/v7.6.0/cudnn-10.1-linux-x64-v7.6.0.64.tgz -O && \
+    echo "$CUDNN_DOWNLOAD_SUM  cudnn-10.1-linux-x64-v7.6.0.64.tgz" | sha256sum -c - && \
+    tar --no-same-owner -xzf cudnn-10.1-linux-x64-v7.6.0.64.tgz -C /usr/local --wildcards 'cuda/lib64/libcudnn.so.*' && \
+    rm cudnn-10.1-linux-x64-v7.6.0.64.tgz && \
     ldconfig

--- a/10.1/runtime/cudnn7/Dockerfile
+++ b/10.1/runtime/cudnn7/Dockerfile
@@ -2,13 +2,13 @@ ARG IMAGE_NAME
 FROM ${IMAGE_NAME}:10.1-runtime-centos7
 LABEL maintainer "NVIDIA CORPORATION <cudatools@nvidia.com>"
 
-ENV CUDNN_VERSION 7.5.0.56
+ENV CUDNN_VERSION 7.5.1.10
 LABEL com.nvidia.cudnn.version="${CUDNN_VERSION}"
 
 # cuDNN license: https://developer.nvidia.com/cudnn/license_agreement
-RUN CUDNN_DOWNLOAD_SUM=c31697d6b71afe62838ad2e57da3c3c9419c4e9f5635d14b683ebe63f904fbc8 && \
-    curl -fsSL http://developer.download.nvidia.com/compute/redist/cudnn/v7.5.0/cudnn-10.1-linux-x64-v7.5.0.56.tgz -O && \
-    echo "$CUDNN_DOWNLOAD_SUM  cudnn-10.1-linux-x64-v7.5.0.56.tgz" | sha256sum -c - && \
-    tar --no-same-owner -xzf cudnn-10.1-linux-x64-v7.5.0.56.tgz -C /usr/local --wildcards 'cuda/lib64/libcudnn.so.*' && \
-    rm cudnn-10.1-linux-x64-v7.5.0.56.tgz && \
+RUN CUDNN_DOWNLOAD_SUM=2c833f43c9147d9a25a20947a4c5a5f5c33b2443240fd767f63b330c482e68e0 && \
+    curl -fsSL http://developer.download.nvidia.com/compute/redist/cudnn/v7.5.1/cudnn-10.1-linux-x64-v7.5.1.10.tgz -O && \
+    echo "$CUDNN_DOWNLOAD_SUM  cudnn-10.1-linux-x64-v7.5.1.10.tgz" | sha256sum -c - && \
+    tar --no-same-owner -xzf cudnn-10.1-linux-x64-v7.5.1.10.tgz -C /usr/local --wildcards 'cuda/lib64/libcudnn.so.*' && \
+    rm cudnn-10.1-linux-x64-v7.5.1.10.tgz && \
     ldconfig

--- a/10.1/runtime/cudnn7/Dockerfile
+++ b/10.1/runtime/cudnn7/Dockerfile
@@ -1,4 +1,4 @@
-ARG IMAGE_NAME
+
 FROM ${IMAGE_NAME}:10.1-runtime-centos7
 LABEL maintainer "NVIDIA CORPORATION <cudatools@nvidia.com>"
 

--- a/8.0/devel/Dockerfile
+++ b/8.0/devel/Dockerfile
@@ -1,4 +1,4 @@
-ARG IMAGE_NAME
+
 FROM ${IMAGE_NAME}:8.0-runtime-centos7
 LABEL maintainer "NVIDIA CORPORATION <cudatools@nvidia.com>"
 

--- a/8.0/devel/cudnn5/Dockerfile
+++ b/8.0/devel/cudnn5/Dockerfile
@@ -1,4 +1,4 @@
-ARG IMAGE_NAME
+
 FROM ${IMAGE_NAME}:8.0-devel-centos7
 LABEL maintainer "NVIDIA CORPORATION <cudatools@nvidia.com>"
 

--- a/8.0/devel/cudnn6/Dockerfile
+++ b/8.0/devel/cudnn6/Dockerfile
@@ -1,4 +1,4 @@
-ARG IMAGE_NAME
+
 FROM ${IMAGE_NAME}:8.0-devel-centos7
 LABEL maintainer "NVIDIA CORPORATION <cudatools@nvidia.com>"
 

--- a/8.0/devel/cudnn7/Dockerfile
+++ b/8.0/devel/cudnn7/Dockerfile
@@ -1,4 +1,4 @@
-ARG IMAGE_NAME
+
 FROM ${IMAGE_NAME}:8.0-devel-centos7
 LABEL maintainer "NVIDIA CORPORATION <cudatools@nvidia.com>"
 

--- a/8.0/runtime/cudnn5/Dockerfile
+++ b/8.0/runtime/cudnn5/Dockerfile
@@ -1,4 +1,4 @@
-ARG IMAGE_NAME
+
 FROM ${IMAGE_NAME}:8.0-runtime-centos7
 LABEL maintainer "NVIDIA CORPORATION <cudatools@nvidia.com>"
 

--- a/8.0/runtime/cudnn6/Dockerfile
+++ b/8.0/runtime/cudnn6/Dockerfile
@@ -1,4 +1,4 @@
-ARG IMAGE_NAME
+
 FROM ${IMAGE_NAME}:8.0-runtime-centos7
 LABEL maintainer "NVIDIA CORPORATION <cudatools@nvidia.com>"
 

--- a/8.0/runtime/cudnn7/Dockerfile
+++ b/8.0/runtime/cudnn7/Dockerfile
@@ -1,4 +1,4 @@
-ARG IMAGE_NAME
+
 FROM ${IMAGE_NAME}:8.0-runtime-centos7
 LABEL maintainer "NVIDIA CORPORATION <cudatools@nvidia.com>"
 

--- a/9.0/devel/Dockerfile
+++ b/9.0/devel/Dockerfile
@@ -1,4 +1,4 @@
-ARG IMAGE_NAME
+
 FROM ${IMAGE_NAME}:9.0-runtime-centos7
 LABEL maintainer "NVIDIA CORPORATION <cudatools@nvidia.com>"
 

--- a/9.0/devel/cudnn7/Dockerfile
+++ b/9.0/devel/cudnn7/Dockerfile
@@ -2,13 +2,13 @@ ARG IMAGE_NAME
 FROM ${IMAGE_NAME}:9.0-devel-centos7
 LABEL maintainer "NVIDIA CORPORATION <cudatools@nvidia.com>"
 
-ENV CUDNN_VERSION 7.5.1.10
+ENV CUDNN_VERSION 7.6.0.64
 LABEL com.nvidia.cudnn.version="${CUDNN_VERSION}"
 
 # cuDNN license: https://developer.nvidia.com/cudnn/license_agreement
-RUN CUDNN_DOWNLOAD_SUM=1abe08839dcb59a3a7293c85f642bf0dd2486e377d0fbca1b0311f38e183251a && \
-    curl -fsSL http://developer.download.nvidia.com/compute/redist/cudnn/v7.5.1/cudnn-9.0-linux-x64-v7.5.1.10.tgz -O && \
-    echo "$CUDNN_DOWNLOAD_SUM  cudnn-9.0-linux-x64-v7.5.1.10.tgz" | sha256sum -c - && \
-    tar --no-same-owner -xzf cudnn-9.0-linux-x64-v7.5.1.10.tgz -C /usr/local && \
-    rm cudnn-9.0-linux-x64-v7.5.1.10.tgz && \
+RUN CUDNN_DOWNLOAD_SUM=90659ea77734b7b671afe930c9898d21a13b888998f1dd3940cc57d6b2f29b86 && \
+    curl -fsSL http://developer.download.nvidia.com/compute/redist/cudnn/v7.6.0/cudnn-9.0-linux-x64-v7.6.0.64.tgz -O && \
+    echo "$CUDNN_DOWNLOAD_SUM  cudnn-9.0-linux-x64-v7.6.0.64.tgz" | sha256sum -c - && \
+    tar --no-same-owner -xzf cudnn-9.0-linux-x64-v7.6.0.64.tgz -C /usr/local && \
+    rm cudnn-9.0-linux-x64-v7.6.0.64.tgz && \
     ldconfig

--- a/9.0/devel/cudnn7/Dockerfile
+++ b/9.0/devel/cudnn7/Dockerfile
@@ -2,13 +2,13 @@ ARG IMAGE_NAME
 FROM ${IMAGE_NAME}:9.0-devel-centos7
 LABEL maintainer "NVIDIA CORPORATION <cudatools@nvidia.com>"
 
-ENV CUDNN_VERSION 7.4.2.24
+ENV CUDNN_VERSION 7.5.0.56
 LABEL com.nvidia.cudnn.version="${CUDNN_VERSION}"
 
 # cuDNN license: https://developer.nvidia.com/cudnn/license_agreement
-RUN CUDNN_DOWNLOAD_SUM=e3e72e9e2bf4c5e4cdd467aa6b824effc4566d230a2cda4153ad894d7d15cf73 && \
-    curl -fsSL http://developer.download.nvidia.com/compute/redist/cudnn/v7.4.2/cudnn-9.0-linux-x64-v7.4.2.24.tgz -O && \
-    echo "$CUDNN_DOWNLOAD_SUM  cudnn-9.0-linux-x64-v7.4.2.24.tgz" | sha256sum -c - && \
-    tar --no-same-owner -xzf cudnn-9.0-linux-x64-v7.4.2.24.tgz -C /usr/local && \
-    rm cudnn-9.0-linux-x64-v7.4.2.24.tgz && \
+RUN CUDNN_DOWNLOAD_SUM=ee0ecd3cc30b9bf5ec875eac3ed375d3996bcb0ed5d2551716e4884b3ea5ce8c && \
+    curl -fsSL http://developer.download.nvidia.com/compute/redist/cudnn/v7.5.0/cudnn-9.0-linux-x64-v7.5.0.56.tgz -O && \
+    echo "$CUDNN_DOWNLOAD_SUM  cudnn-9.0-linux-x64-v7.5.0.56.tgz" | sha256sum -c - && \
+    tar --no-same-owner -xzf cudnn-9.0-linux-x64-v7.5.0.56.tgz -C /usr/local && \
+    rm cudnn-9.0-linux-x64-v7.5.0.56.tgz && \
     ldconfig

--- a/9.0/devel/cudnn7/Dockerfile
+++ b/9.0/devel/cudnn7/Dockerfile
@@ -2,13 +2,13 @@ ARG IMAGE_NAME
 FROM ${IMAGE_NAME}:9.0-devel-centos7
 LABEL maintainer "NVIDIA CORPORATION <cudatools@nvidia.com>"
 
-ENV CUDNN_VERSION 7.5.0.56
+ENV CUDNN_VERSION 7.5.1.10
 LABEL com.nvidia.cudnn.version="${CUDNN_VERSION}"
 
 # cuDNN license: https://developer.nvidia.com/cudnn/license_agreement
-RUN CUDNN_DOWNLOAD_SUM=ee0ecd3cc30b9bf5ec875eac3ed375d3996bcb0ed5d2551716e4884b3ea5ce8c && \
-    curl -fsSL http://developer.download.nvidia.com/compute/redist/cudnn/v7.5.0/cudnn-9.0-linux-x64-v7.5.0.56.tgz -O && \
-    echo "$CUDNN_DOWNLOAD_SUM  cudnn-9.0-linux-x64-v7.5.0.56.tgz" | sha256sum -c - && \
-    tar --no-same-owner -xzf cudnn-9.0-linux-x64-v7.5.0.56.tgz -C /usr/local && \
-    rm cudnn-9.0-linux-x64-v7.5.0.56.tgz && \
+RUN CUDNN_DOWNLOAD_SUM=1abe08839dcb59a3a7293c85f642bf0dd2486e377d0fbca1b0311f38e183251a && \
+    curl -fsSL http://developer.download.nvidia.com/compute/redist/cudnn/v7.5.1/cudnn-9.0-linux-x64-v7.5.1.10.tgz -O && \
+    echo "$CUDNN_DOWNLOAD_SUM  cudnn-9.0-linux-x64-v7.5.1.10.tgz" | sha256sum -c - && \
+    tar --no-same-owner -xzf cudnn-9.0-linux-x64-v7.5.1.10.tgz -C /usr/local && \
+    rm cudnn-9.0-linux-x64-v7.5.1.10.tgz && \
     ldconfig

--- a/9.0/devel/cudnn7/Dockerfile
+++ b/9.0/devel/cudnn7/Dockerfile
@@ -1,4 +1,4 @@
-ARG IMAGE_NAME
+
 FROM ${IMAGE_NAME}:9.0-devel-centos7
 LABEL maintainer "NVIDIA CORPORATION <cudatools@nvidia.com>"
 

--- a/9.0/runtime/Dockerfile
+++ b/9.0/runtime/Dockerfile
@@ -1,4 +1,4 @@
-ARG IMAGE_NAME
+
 FROM ${IMAGE_NAME}:9.0-base-centos7
 LABEL maintainer "NVIDIA CORPORATION <cudatools@nvidia.com>"
 

--- a/9.0/runtime/cudnn7/Dockerfile
+++ b/9.0/runtime/cudnn7/Dockerfile
@@ -2,13 +2,13 @@ ARG IMAGE_NAME
 FROM ${IMAGE_NAME}:9.0-runtime-centos7
 LABEL maintainer "NVIDIA CORPORATION <cudatools@nvidia.com>"
 
-ENV CUDNN_VERSION 7.4.2.24
+ENV CUDNN_VERSION 7.5.0.56
 LABEL com.nvidia.cudnn.version="${CUDNN_VERSION}"
 
 # cuDNN license: https://developer.nvidia.com/cudnn/license_agreement
-RUN CUDNN_DOWNLOAD_SUM=e3e72e9e2bf4c5e4cdd467aa6b824effc4566d230a2cda4153ad894d7d15cf73 && \
-    curl -fsSL http://developer.download.nvidia.com/compute/redist/cudnn/v7.4.2/cudnn-9.0-linux-x64-v7.4.2.24.tgz -O && \
-    echo "$CUDNN_DOWNLOAD_SUM  cudnn-9.0-linux-x64-v7.4.2.24.tgz" | sha256sum -c - && \
-    tar --no-same-owner -xzf cudnn-9.0-linux-x64-v7.4.2.24.tgz -C /usr/local --wildcards 'cuda/lib64/libcudnn.so.*' && \
-    rm cudnn-9.0-linux-x64-v7.4.2.24.tgz && \
+RUN CUDNN_DOWNLOAD_SUM=ee0ecd3cc30b9bf5ec875eac3ed375d3996bcb0ed5d2551716e4884b3ea5ce8c && \
+    curl -fsSL http://developer.download.nvidia.com/compute/redist/cudnn/v7.5.0/cudnn-9.0-linux-x64-v7.5.0.56.tgz -O && \
+    echo "$CUDNN_DOWNLOAD_SUM  cudnn-9.0-linux-x64-v7.5.0.56.tgz" | sha256sum -c - && \
+    tar --no-same-owner -xzf cudnn-9.0-linux-x64-v7.5.0.56.tgz -C /usr/local --wildcards 'cuda/lib64/libcudnn.so.*' && \
+    rm cudnn-9.0-linux-x64-v7.5.0.56.tgz && \
     ldconfig

--- a/9.0/runtime/cudnn7/Dockerfile
+++ b/9.0/runtime/cudnn7/Dockerfile
@@ -2,13 +2,13 @@ ARG IMAGE_NAME
 FROM ${IMAGE_NAME}:9.0-runtime-centos7
 LABEL maintainer "NVIDIA CORPORATION <cudatools@nvidia.com>"
 
-ENV CUDNN_VERSION 7.5.1.10
+ENV CUDNN_VERSION 7.6.0.64
 LABEL com.nvidia.cudnn.version="${CUDNN_VERSION}"
 
 # cuDNN license: https://developer.nvidia.com/cudnn/license_agreement
-RUN CUDNN_DOWNLOAD_SUM=1abe08839dcb59a3a7293c85f642bf0dd2486e377d0fbca1b0311f38e183251a && \
-    curl -fsSL http://developer.download.nvidia.com/compute/redist/cudnn/v7.5.1/cudnn-9.0-linux-x64-v7.5.1.10.tgz -O && \
-    echo "$CUDNN_DOWNLOAD_SUM  cudnn-9.0-linux-x64-v7.5.1.10.tgz" | sha256sum -c - && \
-    tar --no-same-owner -xzf cudnn-9.0-linux-x64-v7.5.1.10.tgz -C /usr/local --wildcards 'cuda/lib64/libcudnn.so.*' && \
-    rm cudnn-9.0-linux-x64-v7.5.1.10.tgz && \
+RUN CUDNN_DOWNLOAD_SUM=90659ea77734b7b671afe930c9898d21a13b888998f1dd3940cc57d6b2f29b86 && \
+    curl -fsSL http://developer.download.nvidia.com/compute/redist/cudnn/v7.6.0/cudnn-9.0-linux-x64-v7.6.0.64.tgz -O && \
+    echo "$CUDNN_DOWNLOAD_SUM  cudnn-9.0-linux-x64-v7.6.0.64.tgz" | sha256sum -c - && \
+    tar --no-same-owner -xzf cudnn-9.0-linux-x64-v7.6.0.64.tgz -C /usr/local --wildcards 'cuda/lib64/libcudnn.so.*' && \
+    rm cudnn-9.0-linux-x64-v7.6.0.64.tgz && \
     ldconfig

--- a/9.0/runtime/cudnn7/Dockerfile
+++ b/9.0/runtime/cudnn7/Dockerfile
@@ -2,13 +2,13 @@ ARG IMAGE_NAME
 FROM ${IMAGE_NAME}:9.0-runtime-centos7
 LABEL maintainer "NVIDIA CORPORATION <cudatools@nvidia.com>"
 
-ENV CUDNN_VERSION 7.5.0.56
+ENV CUDNN_VERSION 7.5.1.10
 LABEL com.nvidia.cudnn.version="${CUDNN_VERSION}"
 
 # cuDNN license: https://developer.nvidia.com/cudnn/license_agreement
-RUN CUDNN_DOWNLOAD_SUM=ee0ecd3cc30b9bf5ec875eac3ed375d3996bcb0ed5d2551716e4884b3ea5ce8c && \
-    curl -fsSL http://developer.download.nvidia.com/compute/redist/cudnn/v7.5.0/cudnn-9.0-linux-x64-v7.5.0.56.tgz -O && \
-    echo "$CUDNN_DOWNLOAD_SUM  cudnn-9.0-linux-x64-v7.5.0.56.tgz" | sha256sum -c - && \
-    tar --no-same-owner -xzf cudnn-9.0-linux-x64-v7.5.0.56.tgz -C /usr/local --wildcards 'cuda/lib64/libcudnn.so.*' && \
-    rm cudnn-9.0-linux-x64-v7.5.0.56.tgz && \
+RUN CUDNN_DOWNLOAD_SUM=1abe08839dcb59a3a7293c85f642bf0dd2486e377d0fbca1b0311f38e183251a && \
+    curl -fsSL http://developer.download.nvidia.com/compute/redist/cudnn/v7.5.1/cudnn-9.0-linux-x64-v7.5.1.10.tgz -O && \
+    echo "$CUDNN_DOWNLOAD_SUM  cudnn-9.0-linux-x64-v7.5.1.10.tgz" | sha256sum -c - && \
+    tar --no-same-owner -xzf cudnn-9.0-linux-x64-v7.5.1.10.tgz -C /usr/local --wildcards 'cuda/lib64/libcudnn.so.*' && \
+    rm cudnn-9.0-linux-x64-v7.5.1.10.tgz && \
     ldconfig

--- a/9.0/runtime/cudnn7/Dockerfile
+++ b/9.0/runtime/cudnn7/Dockerfile
@@ -1,4 +1,4 @@
-ARG IMAGE_NAME
+
 FROM ${IMAGE_NAME}:9.0-runtime-centos7
 LABEL maintainer "NVIDIA CORPORATION <cudatools@nvidia.com>"
 

--- a/9.1/devel/Dockerfile
+++ b/9.1/devel/Dockerfile
@@ -1,4 +1,4 @@
-ARG IMAGE_NAME
+
 FROM ${IMAGE_NAME}:9.1-runtime-centos7
 LABEL maintainer "NVIDIA CORPORATION <cudatools@nvidia.com>"
 

--- a/9.1/devel/cudnn7/Dockerfile
+++ b/9.1/devel/cudnn7/Dockerfile
@@ -1,4 +1,4 @@
-ARG IMAGE_NAME
+
 FROM ${IMAGE_NAME}:9.1-devel-centos7
 LABEL maintainer "NVIDIA CORPORATION <cudatools@nvidia.com>"
 

--- a/9.1/runtime/Dockerfile
+++ b/9.1/runtime/Dockerfile
@@ -1,4 +1,4 @@
-ARG IMAGE_NAME
+
 FROM ${IMAGE_NAME}:9.1-base-centos7
 LABEL maintainer "NVIDIA CORPORATION <cudatools@nvidia.com>"
 

--- a/9.1/runtime/cudnn7/Dockerfile
+++ b/9.1/runtime/cudnn7/Dockerfile
@@ -1,4 +1,4 @@
-ARG IMAGE_NAME
+
 FROM ${IMAGE_NAME}:9.1-runtime-centos7
 LABEL maintainer "NVIDIA CORPORATION <cudatools@nvidia.com>"
 

--- a/9.2/devel/Dockerfile
+++ b/9.2/devel/Dockerfile
@@ -1,4 +1,4 @@
-ARG IMAGE_NAME
+
 FROM ${IMAGE_NAME}:9.2-runtime-centos7
 LABEL maintainer "NVIDIA CORPORATION <cudatools@nvidia.com>"
 

--- a/9.2/devel/cudnn7/Dockerfile
+++ b/9.2/devel/cudnn7/Dockerfile
@@ -2,13 +2,13 @@ ARG IMAGE_NAME
 FROM ${IMAGE_NAME}:9.2-devel-centos7
 LABEL maintainer "NVIDIA CORPORATION <cudatools@nvidia.com>"
 
-ENV CUDNN_VERSION 7.5.1.10
+ENV CUDNN_VERSION 7.6.0.64
 LABEL com.nvidia.cudnn.version="${CUDNN_VERSION}"
 
 # cuDNN license: https://developer.nvidia.com/cudnn/license_agreement
-RUN CUDNN_DOWNLOAD_SUM=e840d29ce5f0c068911966e62128397c6a9bb5e2ea9c66394a592c3b61e770a5 && \
-    curl -fsSL http://developer.download.nvidia.com/compute/redist/cudnn/v7.5.1/cudnn-9.2-linux-x64-v7.5.1.10.tgz -O && \
-    echo "$CUDNN_DOWNLOAD_SUM  cudnn-9.2-linux-x64-v7.5.1.10.tgz" | sha256sum -c - && \
-    tar --no-same-owner -xzf cudnn-9.2-linux-x64-v7.5.1.10.tgz -C /usr/local && \
-    rm cudnn-9.2-linux-x64-v7.5.1.10.tgz && \
+RUN CUDNN_DOWNLOAD_SUM=ff028e6f07349445c16fef704a90bccb0992c3e012bba66ab1da352bad55b304 && \
+    curl -fsSL http://developer.download.nvidia.com/compute/redist/cudnn/v7.6.0/cudnn-9.2-linux-x64-v7.6.0.64.tgz -O && \
+    echo "$CUDNN_DOWNLOAD_SUM  cudnn-9.2-linux-x64-v7.6.0.64.tgz" | sha256sum -c - && \
+    tar --no-same-owner -xzf cudnn-9.2-linux-x64-v7.6.0.64.tgz -C /usr/local && \
+    rm cudnn-9.2-linux-x64-v7.6.0.64.tgz && \
     ldconfig

--- a/9.2/devel/cudnn7/Dockerfile
+++ b/9.2/devel/cudnn7/Dockerfile
@@ -2,13 +2,13 @@ ARG IMAGE_NAME
 FROM ${IMAGE_NAME}:9.2-devel-centos7
 LABEL maintainer "NVIDIA CORPORATION <cudatools@nvidia.com>"
 
-ENV CUDNN_VERSION 7.5.0.56
+ENV CUDNN_VERSION 7.5.1.10
 LABEL com.nvidia.cudnn.version="${CUDNN_VERSION}"
 
 # cuDNN license: https://developer.nvidia.com/cudnn/license_agreement
-RUN CUDNN_DOWNLOAD_SUM=2a04fd5ed5b8d32e2401c85a1a38f3cfd6da662c31bd26e80bea25469e48a675 && \
-    curl -fsSL http://developer.download.nvidia.com/compute/redist/cudnn/v7.5.0/cudnn-9.2-linux-x64-v7.5.0.56.tgz -O && \
-    echo "$CUDNN_DOWNLOAD_SUM  cudnn-9.2-linux-x64-v7.5.0.56.tgz" | sha256sum -c - && \
-    tar --no-same-owner -xzf cudnn-9.2-linux-x64-v7.5.0.56.tgz -C /usr/local && \
-    rm cudnn-9.2-linux-x64-v7.5.0.56.tgz && \
+RUN CUDNN_DOWNLOAD_SUM=e840d29ce5f0c068911966e62128397c6a9bb5e2ea9c66394a592c3b61e770a5 && \
+    curl -fsSL http://developer.download.nvidia.com/compute/redist/cudnn/v7.5.1/cudnn-9.2-linux-x64-v7.5.1.10.tgz -O && \
+    echo "$CUDNN_DOWNLOAD_SUM  cudnn-9.2-linux-x64-v7.5.1.10.tgz" | sha256sum -c - && \
+    tar --no-same-owner -xzf cudnn-9.2-linux-x64-v7.5.1.10.tgz -C /usr/local && \
+    rm cudnn-9.2-linux-x64-v7.5.1.10.tgz && \
     ldconfig

--- a/9.2/devel/cudnn7/Dockerfile
+++ b/9.2/devel/cudnn7/Dockerfile
@@ -2,13 +2,13 @@ ARG IMAGE_NAME
 FROM ${IMAGE_NAME}:9.2-devel-centos7
 LABEL maintainer "NVIDIA CORPORATION <cudatools@nvidia.com>"
 
-ENV CUDNN_VERSION 7.4.2.24
+ENV CUDNN_VERSION 7.5.0.56
 LABEL com.nvidia.cudnn.version="${CUDNN_VERSION}"
 
 # cuDNN license: https://developer.nvidia.com/cudnn/license_agreement
-RUN CUDNN_DOWNLOAD_SUM=19565be5dba39097d59f99227fd65cd2f3a3be9e4249500f772d4b14c7806371 && \
-    curl -fsSL http://developer.download.nvidia.com/compute/redist/cudnn/v7.4.2/cudnn-9.2-linux-x64-v7.4.2.24.tgz -O && \
-    echo "$CUDNN_DOWNLOAD_SUM  cudnn-9.2-linux-x64-v7.4.2.24.tgz" | sha256sum -c - && \
-    tar --no-same-owner -xzf cudnn-9.2-linux-x64-v7.4.2.24.tgz -C /usr/local && \
-    rm cudnn-9.2-linux-x64-v7.4.2.24.tgz && \
+RUN CUDNN_DOWNLOAD_SUM=2a04fd5ed5b8d32e2401c85a1a38f3cfd6da662c31bd26e80bea25469e48a675 && \
+    curl -fsSL http://developer.download.nvidia.com/compute/redist/cudnn/v7.5.0/cudnn-9.2-linux-x64-v7.5.0.56.tgz -O && \
+    echo "$CUDNN_DOWNLOAD_SUM  cudnn-9.2-linux-x64-v7.5.0.56.tgz" | sha256sum -c - && \
+    tar --no-same-owner -xzf cudnn-9.2-linux-x64-v7.5.0.56.tgz -C /usr/local && \
+    rm cudnn-9.2-linux-x64-v7.5.0.56.tgz && \
     ldconfig

--- a/9.2/devel/cudnn7/Dockerfile
+++ b/9.2/devel/cudnn7/Dockerfile
@@ -1,4 +1,4 @@
-ARG IMAGE_NAME
+
 FROM ${IMAGE_NAME}:9.2-devel-centos7
 LABEL maintainer "NVIDIA CORPORATION <cudatools@nvidia.com>"
 

--- a/9.2/runtime/Dockerfile
+++ b/9.2/runtime/Dockerfile
@@ -1,4 +1,4 @@
-ARG IMAGE_NAME
+
 FROM ${IMAGE_NAME}:9.2-base-centos7
 LABEL maintainer "NVIDIA CORPORATION <cudatools@nvidia.com>"
 

--- a/9.2/runtime/cudnn7/Dockerfile
+++ b/9.2/runtime/cudnn7/Dockerfile
@@ -2,13 +2,13 @@ ARG IMAGE_NAME
 FROM ${IMAGE_NAME}:9.2-runtime-centos7
 LABEL maintainer "NVIDIA CORPORATION <cudatools@nvidia.com>"
 
-ENV CUDNN_VERSION 7.5.0.56
+ENV CUDNN_VERSION 7.5.1.10
 LABEL com.nvidia.cudnn.version="${CUDNN_VERSION}"
 
 # cuDNN license: https://developer.nvidia.com/cudnn/license_agreement
-RUN CUDNN_DOWNLOAD_SUM=2a04fd5ed5b8d32e2401c85a1a38f3cfd6da662c31bd26e80bea25469e48a675 && \
-    curl -fsSL http://developer.download.nvidia.com/compute/redist/cudnn/v7.5.0/cudnn-9.2-linux-x64-v7.5.0.56.tgz -O && \
-    echo "$CUDNN_DOWNLOAD_SUM  cudnn-9.2-linux-x64-v7.5.0.56.tgz" | sha256sum -c - && \
-    tar --no-same-owner -xzf cudnn-9.2-linux-x64-v7.5.0.56.tgz -C /usr/local --wildcards 'cuda/lib64/libcudnn.so.*' && \
-    rm cudnn-9.2-linux-x64-v7.5.0.56.tgz && \
+RUN CUDNN_DOWNLOAD_SUM=e840d29ce5f0c068911966e62128397c6a9bb5e2ea9c66394a592c3b61e770a5 && \
+    curl -fsSL http://developer.download.nvidia.com/compute/redist/cudnn/v7.5.1/cudnn-9.2-linux-x64-v7.5.1.10.tgz -O && \
+    echo "$CUDNN_DOWNLOAD_SUM  cudnn-9.2-linux-x64-v7.5.1.10.tgz" | sha256sum -c - && \
+    tar --no-same-owner -xzf cudnn-9.2-linux-x64-v7.5.1.10.tgz -C /usr/local --wildcards 'cuda/lib64/libcudnn.so.*' && \
+    rm cudnn-9.2-linux-x64-v7.5.1.10.tgz && \
     ldconfig

--- a/9.2/runtime/cudnn7/Dockerfile
+++ b/9.2/runtime/cudnn7/Dockerfile
@@ -2,13 +2,13 @@ ARG IMAGE_NAME
 FROM ${IMAGE_NAME}:9.2-runtime-centos7
 LABEL maintainer "NVIDIA CORPORATION <cudatools@nvidia.com>"
 
-ENV CUDNN_VERSION 7.4.2.24
+ENV CUDNN_VERSION 7.5.0.56
 LABEL com.nvidia.cudnn.version="${CUDNN_VERSION}"
 
 # cuDNN license: https://developer.nvidia.com/cudnn/license_agreement
-RUN CUDNN_DOWNLOAD_SUM=19565be5dba39097d59f99227fd65cd2f3a3be9e4249500f772d4b14c7806371 && \
-    curl -fsSL http://developer.download.nvidia.com/compute/redist/cudnn/v7.4.2/cudnn-9.2-linux-x64-v7.4.2.24.tgz -O && \
-    echo "$CUDNN_DOWNLOAD_SUM  cudnn-9.2-linux-x64-v7.4.2.24.tgz" | sha256sum -c - && \
-    tar --no-same-owner -xzf cudnn-9.2-linux-x64-v7.4.2.24.tgz -C /usr/local --wildcards 'cuda/lib64/libcudnn.so.*' && \
-    rm cudnn-9.2-linux-x64-v7.4.2.24.tgz && \
+RUN CUDNN_DOWNLOAD_SUM=2a04fd5ed5b8d32e2401c85a1a38f3cfd6da662c31bd26e80bea25469e48a675 && \
+    curl -fsSL http://developer.download.nvidia.com/compute/redist/cudnn/v7.5.0/cudnn-9.2-linux-x64-v7.5.0.56.tgz -O && \
+    echo "$CUDNN_DOWNLOAD_SUM  cudnn-9.2-linux-x64-v7.5.0.56.tgz" | sha256sum -c - && \
+    tar --no-same-owner -xzf cudnn-9.2-linux-x64-v7.5.0.56.tgz -C /usr/local --wildcards 'cuda/lib64/libcudnn.so.*' && \
+    rm cudnn-9.2-linux-x64-v7.5.0.56.tgz && \
     ldconfig

--- a/9.2/runtime/cudnn7/Dockerfile
+++ b/9.2/runtime/cudnn7/Dockerfile
@@ -2,13 +2,13 @@ ARG IMAGE_NAME
 FROM ${IMAGE_NAME}:9.2-runtime-centos7
 LABEL maintainer "NVIDIA CORPORATION <cudatools@nvidia.com>"
 
-ENV CUDNN_VERSION 7.5.1.10
+ENV CUDNN_VERSION 7.6.0.64
 LABEL com.nvidia.cudnn.version="${CUDNN_VERSION}"
 
 # cuDNN license: https://developer.nvidia.com/cudnn/license_agreement
-RUN CUDNN_DOWNLOAD_SUM=e840d29ce5f0c068911966e62128397c6a9bb5e2ea9c66394a592c3b61e770a5 && \
-    curl -fsSL http://developer.download.nvidia.com/compute/redist/cudnn/v7.5.1/cudnn-9.2-linux-x64-v7.5.1.10.tgz -O && \
-    echo "$CUDNN_DOWNLOAD_SUM  cudnn-9.2-linux-x64-v7.5.1.10.tgz" | sha256sum -c - && \
-    tar --no-same-owner -xzf cudnn-9.2-linux-x64-v7.5.1.10.tgz -C /usr/local --wildcards 'cuda/lib64/libcudnn.so.*' && \
-    rm cudnn-9.2-linux-x64-v7.5.1.10.tgz && \
+RUN CUDNN_DOWNLOAD_SUM=ff028e6f07349445c16fef704a90bccb0992c3e012bba66ab1da352bad55b304 && \
+    curl -fsSL http://developer.download.nvidia.com/compute/redist/cudnn/v7.6.0/cudnn-9.2-linux-x64-v7.6.0.64.tgz -O && \
+    echo "$CUDNN_DOWNLOAD_SUM  cudnn-9.2-linux-x64-v7.6.0.64.tgz" | sha256sum -c - && \
+    tar --no-same-owner -xzf cudnn-9.2-linux-x64-v7.6.0.64.tgz -C /usr/local --wildcards 'cuda/lib64/libcudnn.so.*' && \
+    rm cudnn-9.2-linux-x64-v7.6.0.64.tgz && \
     ldconfig

--- a/9.2/runtime/cudnn7/Dockerfile
+++ b/9.2/runtime/cudnn7/Dockerfile
@@ -1,4 +1,4 @@
-ARG IMAGE_NAME
+
 FROM ${IMAGE_NAME}:9.2-runtime-centos7
 LABEL maintainer "NVIDIA CORPORATION <cudatools@nvidia.com>"
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,15 @@
 # CentOS 7 [![build status](https://gitlab.com/nvidia/cuda/badges/centos7/build.svg)](https://gitlab.com/nvidia/cuda/commits/centos7)
 
+## CUDA 10.1 update 1 (requires nvidia-docker v2)
+
+- [`10.1-base-centos7` (*10.1/base/Dockerfile*)](https://gitlab.com/nvidia/cuda/blob/centos7/10.1/base/Dockerfile)
+- [`10.1-runtime-centos7` (*10.1/runtime/Dockerfile*)](https://gitlab.com/nvidia/cuda/blob/centos7/10.1/runtime/Dockerfile)
+- [`10.1-devel-centos7` (*10.1/devel/Dockerfile*)](https://gitlab.com/nvidia/cuda/blob/centos7/10.1/devel/Dockerfile)
+- [`10.1-cudnn7-runtime-centos7` (*10.1/runtime/cudnn7/Dockerfile*)](https://gitlab.com/nvidia/cuda/blob/centos7/10.1/runtime/cudnn7/Dockerfile)
+- [`10.1-cudnn7-devel-centos7` (*10.1/devel/cudnn7/Dockerfile*)](https://gitlab.com/nvidia/cuda/blob/centos7/10.1/devel/cudnn7/Dockerfile)
+
 ## CUDA 10.0 (requires nvidia-docker v2)
+
 - [`10.0-base-centos7` (*10.0/base/Dockerfile*)](https://gitlab.com/nvidia/cuda/blob/centos7/10.0/base/Dockerfile)
 - [`10.0-runtime-centos7` (*10.0/runtime/Dockerfile*)](https://gitlab.com/nvidia/cuda/blob/centos7/10.0/runtime/Dockerfile)
 - [`10.0-devel-centos7` (*10.0/devel/Dockerfile*)](https://gitlab.com/nvidia/cuda/blob/centos7/10.0/devel/Dockerfile)
@@ -8,6 +17,7 @@
 - [`10.0-cudnn7-devel-centos7` (*10.0/devel/cudnn7/Dockerfile*)](https://gitlab.com/nvidia/cuda/blob/centos7/10.0/devel/cudnn7/Dockerfile)
 
 ## CUDA 9.2
+
 - [`9.2-base-centos7` (*9.2/base/Dockerfile*)](https://gitlab.com/nvidia/cuda/blob/centos7/9.2/base/Dockerfile)
 - [`9.2-runtime-centos7` (*9.2/runtime/Dockerfile*)](https://gitlab.com/nvidia/cuda/blob/centos7/9.2/runtime/Dockerfile)
 - [`9.2-devel-centos7` (*9.2/devel/Dockerfile*)](https://gitlab.com/nvidia/cuda/blob/centos7/9.2/devel/Dockerfile)
@@ -15,6 +25,7 @@
 - [`9.2-cudnn7-devel-centos7` (*9.2/devel/cudnn7/Dockerfile*)](https://gitlab.com/nvidia/cuda/blob/centos7/9.2/devel/cudnn7/Dockerfile)
 
 ## CUDA 9.1
+
 - [`9.1-base-centos7` (*9.1/base/Dockerfile*)](https://gitlab.com/nvidia/cuda/blob/centos7/9.1/base/Dockerfile)
 - [`9.1-runtime-centos7` (*9.1/runtime/Dockerfile*)](https://gitlab.com/nvidia/cuda/blob/centos7/9.1/runtime/Dockerfile)
 - [`9.1-devel-centos7` (*9.1/devel/Dockerfile*)](https://gitlab.com/nvidia/cuda/blob/centos7/9.1/devel/Dockerfile)
@@ -22,6 +33,7 @@
 - [`9.1-cudnn7-devel-centos7` (*9.1/devel/cudnn7/Dockerfile*)](https://gitlab.com/nvidia/cuda/blob/centos7/9.1/devel/cudnn7/Dockerfile)
 
 ## CUDA 9.0
+
 - [`9.0-base-centos7` (*9.0/base/Dockerfile*)](https://gitlab.com/nvidia/cuda/blob/centos7/9.0/base/Dockerfile)
 - [`9.0-runtime-centos7` (*9.0/runtime/Dockerfile*)](https://gitlab.com/nvidia/cuda/blob/centos7/9.0/runtime/Dockerfile)
 - [`9.0-devel-centos7` (*9.0/devel/Dockerfile*)](https://gitlab.com/nvidia/cuda/blob/centos7/9.0/devel/Dockerfile)
@@ -29,6 +41,7 @@
 - [`9.0-cudnn7-devel-centos7` (*9.0/devel/cudnn7/Dockerfile*)](https://gitlab.com/nvidia/cuda/blob/centos7/9.0/devel/cudnn7/Dockerfile)
 
 ## CUDA 8.0
+
 - [`8.0-runtime-centos7` (*8.0/runtime/Dockerfile*)](https://gitlab.com/nvidia/cuda/blob/centos7/8.0/runtime/Dockerfile)
 - [`8.0-devel-centos7` (*8.0/devel/Dockerfile*)](https://gitlab.com/nvidia/cuda/blob/centos7/8.0/devel/Dockerfile)
 - [`8.0-cudnn7-runtime-centos7` (*8.0/runtime/cudnn7/Dockerfile*)](https://gitlab.com/nvidia/cuda/blob/centos7/8.0/runtime/cudnn7/Dockerfile)
@@ -39,6 +52,7 @@
 - [`8.0-cudnn5-devel-centos7` (*8.0/devel/cudnn5/Dockerfile*)](https://gitlab.com/nvidia/cuda/blob/centos7/8.0/devel/cudnn5/Dockerfile)
 
 ## CUDA 7.5
+
 - [`7.5-runtime-centos7` (*7.5/runtime/Dockerfile*)](https://gitlab.com/nvidia/cuda/blob/centos7/7.5/runtime/Dockerfile)
 - [`7.5-devel-centos7` (*7.5/devel/Dockerfile*)](https://gitlab.com/nvidia/cuda/blob/centos7/7.5/devel/Dockerfile)
 - [`7.5-cudnn6-runtime-centos7` (*7.5/runtime/cudnn6/Dockerfile*)](https://gitlab.com/nvidia/cuda/blob/centos7/7.5/runtime/cudnn6/Dockerfile)
@@ -49,6 +63,7 @@
 - [`7.5-cudnn4-devel-centos7` (*7.5/devel/cudnn4/Dockerfile*)](https://gitlab.com/nvidia/cuda/blob/centos7/7.5/devel/cudnn4/Dockerfile)
 
 ## CUDA 7.0
+
 - [`7.0-runtime-centos7` (*7.0/runtime/Dockerfile*)](https://gitlab.com/nvidia/cuda/blob/centos7/7.0/runtime/Dockerfile)
 - [`7.0-devel-centos7` (*7.0/devel/Dockerfile*)](https://gitlab.com/nvidia/cuda/blob/centos7/7.0/devel/Dockerfile)
 - [`7.0-cudnn4-runtime-centos7` (*7.0/runtime/cudnn4/Dockerfile*)](https://gitlab.com/nvidia/cuda/blob/centos7/7.0/runtime/cudnn4/Dockerfile)


### PR DESCRIPTION
As nvidia maintains the repository with regards to branches, we keep our copy in sync for internal cuda image builds.

Related-to: https://github.com/thoth-station/tensorflow-build-s2i/issues/40